### PR TITLE
Fixed a critical application non-exit bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A highly concurrent TCP port scanner.
 `./fglps -host localhost`
 
 ### See the built-in help
-`./fglps --help`
+`./fglps -help`
 
 ## TODO
 - Add support for IP range scanning, instead of single host scanning.


### PR DESCRIPTION
- Fixed a CRITICAL bug where the application wouldn't quit due to a misalignment of the wait groups.
- Removed the use of channels, as it wasn't actually required, and was potentially causing minimal channel sending/receiving contention.
- Refactored the goroutine spawning code.
- Fixed a README typo.